### PR TITLE
Update 0.0.24: Prysm v1.3.6

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.23.tar.xz",
-    "hash": "/ipfs/QmRYmdk63UbQZunk7gNSyzFxRknTYHex9kCiHYL9MrVxZW",
-    "size": 60118200,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.24.tar.xz",
+    "hash": "/ipfs/QmepznYNTyTEunonWgiuUGmMMWDtyxAdA2RhCBeJSoom5Y",
+    "size": 60122340,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.23",
-  "upstream": "v1.3.5",
+  "version": "0.0.24",
+  "upstream": "v1.3.6",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.23'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.24'
     build:
       context: ./build
       args:
-        VERSION: v1.3.5
+        VERSION: v1.3.6
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -432,5 +432,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Tue, 30 Mar 2021 06:41:26 GMT"
     }
+  },
+  "0.0.24": {
+    "hash": "/ipfs/QmPYi1w4u5P8xfVsJ57U7r3NzhvVGhz2vBf5Den5dCW2dY",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 07 Apr 2021 05:50:45 GMT"
+    }
   }
 }


### PR DESCRIPTION
Hash /ipfs/QmPYi1w4u5P8xfVsJ57U7r3NzhvVGhz2vBf5Den5dCW2dY

Features: 
- Advancements in peer scoring

Security: 
- This release contains an update to the most recent blst cryptography library. Updating to this release is strongly recommended.