### PR TITLE
Update 0.0.28: Prysm v1.3.9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ RUN rm -Rf build && yarn run build
 
 WORKDIR /app/
 ENV DOWNLOAD_URL https://github.com/prysmaticlabs/prysm/releases/download
-ENV BINARY_URL ${DOWNLOAD_URL}/v1.3.8-hotfix%2B6c0942/beacon-chain-${VERSION}-linux-amd64
+ENV BINARY_URL ${DOWNLOAD_URL}/${VERSION}/beacon-chain-${VERSION}-linux-amd64
 
 RUN wget $BINARY_URL -O beaconchain && \
     chmod +x  beaconchain

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.27.tar.xz",
-    "hash": "/ipfs/QmZfCKb5XjQbPCUPSj52H5wMucwjm5Y4mVKBdBNHcZ6A9A",
-    "size": 56869976,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.28.tar.xz",
+    "hash": "/ipfs/QmUXhXCBSa8VaUXHBYHsxUpGEDcdYTgkRNW3F2nHwfpcfc",
+    "size": 62108048,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.27",
-  "upstream": "v1.3.8-hotfix.6c0942",
+  "version": "0.0.28",
+  "upstream": "v1.3.9",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.27'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.28'
     build:
       context: ./build
       args:
-        VERSION: v1.3.8-hotfix.6c0942
+        VERSION: v1.3.9
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -460,5 +460,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Sun, 25 Apr 2021 06:44:45 GMT"
     }
+  },
+  "0.0.28": {
+    "hash": "/ipfs/QmQ9vogQzPXLXxVUFhhbQuBjAeqnPrqdHToiqLFiZigqBY",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 12 May 2021 19:51:39 GMT"
+    }
   }
 }


### PR DESCRIPTION
Update 0.0.28: Prysm v1.3.9

Manifest hash : /ipfs/QmQ9vogQzPXLXxVUFhhbQuBjAeqnPrqdHToiqLFiZigqBY

release notes:  https://github.com/prysmaticlabs/prysm/releases

```
This release has a number of important changes, including a fix for a mainnet issue that was issued as a "hotfix".

    Initialize Data Correctly For Powchain Service #8812
    Independent eth1 voting #8811

Updating to this release is recommended as there are a number of improvements since v1.3.8 and v1.3.8-hotfix+6c0942.
```