### PR TITLE
Update 0.0.29: Prysm v1.3.10

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.28.tar.xz",
-    "hash": "/ipfs/QmUXhXCBSa8VaUXHBYHsxUpGEDcdYTgkRNW3F2nHwfpcfc",
-    "size": 62108048,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.29.tar.xz",
+    "hash": "/ipfs/QmSXRHQsj2iJqKe5t2JhDRDbDeU84JZpVwwtsfQttvSvKq",
+    "size": 60869816,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.28",
-  "upstream": "v1.3.9",
+  "version": "0.0.29",
+  "upstream": "v1.3.10",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.28'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.29'
     build:
       context: ./build
       args:
-        VERSION: v1.3.9
+        VERSION: v1.3.10
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -467,5 +467,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 12 May 2021 19:51:39 GMT"
     }
+  },
+  "0.0.29": {
+    "hash": "/ipfs/QmZtpNahMWWXw2r9xH9i8aSFLWGqbazFz4qr5x9sspe9ZC",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Wed, 02 Jun 2021 18:56:14 GMT"
+    }
   }
 }


### PR DESCRIPTION
This release contains a security fix and it is recommended that everyone update as soon as practical.

Manifest hash : /ipfs/QmZtpNahMWWXw2r9xH9i8aSFLWGqbazFz4qr5x9sspe9ZC