### PR TITLE
Update 0.0.30: Prysm v1.3.11

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.29.tar.xz",
-    "hash": "/ipfs/QmSXRHQsj2iJqKe5t2JhDRDbDeU84JZpVwwtsfQttvSvKq",
-    "size": 60869816,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.30.tar.xz",
+    "hash": "/ipfs/QmaNhcrVfQjqYgbUttkYBa9tSvtXP2i4rHVCawsVbnA6cS",
+    "size": 60917708,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.29",
-  "upstream": "v1.3.10",
+  "version": "0.0.30",
+  "upstream": "v1.3.11",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.29'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.30'
     build:
       context: ./build
       args:
-        VERSION: v1.3.10
+        VERSION: v1.3.11
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -474,5 +474,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Wed, 02 Jun 2021 18:56:14 GMT"
     }
+  },
+  "0.0.30": {
+    "hash": "/ipfs/QmexPpSKaQwVVkGFiqiN38otioLWUx6RbeLika8NQb7pfF",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 17 Jun 2021 12:17:07 GMT"
+    }
   }
 }


### PR DESCRIPTION
Prysm 1.3.11

Notable changes:
```
* Update web-ui: Fixes UI display issues
* Client stats graceful failure handling #8976
* Cache eviction policy for committees changed to LRU. 
Full list of changes: https://github.com/prysmaticlabs/prysm/releases/tag/v1.3.11
```
Manifest hash : /ipfs/QmexPpSKaQwVVkGFiqiN38otioLWUx6RbeLika8NQb7pfF
http://my.dappnode/#/installer/%2Fipfs%2FQmexPpSKaQwVVkGFiqiN38otioLWUx6RbeLika8NQb7pfF