### PR TITLE
Update 0.0.31: Prysm v1.4.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.30.tar.xz",
-    "hash": "/ipfs/QmaNhcrVfQjqYgbUttkYBa9tSvtXP2i4rHVCawsVbnA6cS",
-    "size": 60917708,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.31.tar.xz",
+    "hash": "/ipfs/QmTNSjTJrA1yNfK5HqK3H1qYDmukr2sUpn28n9d8fbtrJh",
+    "size": 59293204,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.30",
-  "upstream": "v1.3.11",
+  "version": "0.0.31",
+  "upstream": "v1.4.1",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
     "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.31.tar.xz",
-    "hash": "/ipfs/QmTNSjTJrA1yNfK5HqK3H1qYDmukr2sUpn28n9d8fbtrJh",
-    "size": 59293204,
+    "hash": "/ipfs/QmVntwgazSBmDrKBuGKS6gnErDMQJ9rvHH3cs9aZYZcVxL",
+    "size": 56590844,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -19,7 +19,7 @@
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
   "version": "0.0.31",
-  "upstream": "v1.4.1",
+  "upstream": "v1.4.2",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        VERSION: v1.4.1
+        VERSION: v1.4.2
     volumes:
       - 'data:/data'
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.30'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.31'
     build:
       context: ./build
       args:
-        VERSION: v1.3.11
+        VERSION: v1.4.1
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -481,5 +481,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Thu, 17 Jun 2021 12:17:07 GMT"
     }
+  },
+  "0.0.31": {
+    "hash": "/ipfs/QmXwPzXj54y4jmD22rD7myYFRaJTgdMJWGds1yqTHbvtmG",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Tue, 20 Jul 2021 19:47:51 GMT"
+    }
   }
 }

--- a/releases.json
+++ b/releases.json
@@ -483,10 +483,10 @@
     }
   },
   "0.0.31": {
-    "hash": "/ipfs/QmXwPzXj54y4jmD22rD7myYFRaJTgdMJWGds1yqTHbvtmG",
+    "hash": "/ipfs/QmSi6AbqisYwdyBzjX3Sa8mD4S8X9wwm5G4ZB2mFqhNiqz",
     "type": "manifest",
     "uploadedTo": {
-      "http://80.208.229.228:5001": "Tue, 20 Jul 2021 19:47:51 GMT"
+      "http://80.208.229.228:5001": "Thu, 22 Jul 2021 16:05:28 GMT"
     }
   }
 }


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/releases/tag/v1.4.1

update to support London hardfork

  Manifest hash : /ipfs/QmSi6AbqisYwdyBzjX3Sa8mD4S8X9wwm5G4ZB2mFqhNiqz
  http://my.dappnode/#/installer/%2Fipfs%2FQmSi6AbqisYwdyBzjX3Sa8mD4S8X9wwm5G4ZB2mFqhNiqz
