### PR TITLE
Update 0.0.34: Prysm v2.0.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.33.tar.xz",
-    "hash": "/ipfs/QmSGou21tcXCjfXujWnFF9ZuNSBAFpaX8xVppsnvy6ZAcR",
-    "size": 59117708,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.34.tar.xz",
+    "hash": "/ipfs/QmbWyJTApL811agR7Ae6aP3DWYJDq1oXboDdZy5tAEVRkg",
+    "size": 60272184,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.33",
-  "upstream": "v1.4.4",
+  "version": "0.0.34",
+  "upstream": "v2.0.0",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.33'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.34'
     build:
       context: ./build
       args:
-        VERSION: v1.4.4
+        VERSION: v2.0.0
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -502,5 +502,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Fri, 10 Sep 2021 14:07:52 GMT"
     }
+  },
+  "0.0.34": {
+    "hash": "/ipfs/QmTYanctJr3CU8Zpcg9UzZorsu7fqoVLKgEoK1ggV3teaU",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Mon, 04 Oct 2021 19:30:58 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/releases/tag/v2.0.0

Full Altair support.
"Please update your beacon node to v2.0.0 prior to updating your validator."

Manifest hash: /ipfs/QmTYanctJr3CU8Zpcg9UzZorsu7fqoVLKgEoK1ggV3teaU