### PR TITLE
Update 0.0.35: Prysm v2.0.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,8 +1,8 @@
 {
   "image": {
-    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.34.tar.xz",
-    "hash": "/ipfs/QmT715N1JU5N8rMnaVxtqAMSqGJXXGW6LaTBctXDUuZKQC",
-    "size": 60276916,
+    "path": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth_0.0.35.tar.xz",
+    "hash": "/ipfs/QmRFd3ALcEZcdoejZ7zEbyFUhVLNTuQoeUaJcK3RWTPJXx",
+    "size": 60285748,
     "ports": [
       "12000:12000/udp",
       "13000:13000"
@@ -18,8 +18,8 @@
   "name": "prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth",
   "autoupdate": true,
   "title": "ETH2.0 Prysm beacon chain",
-  "version": "0.0.34",
-  "upstream": "v2.0.0",
+  "version": "0.0.35",
+  "upstream": "v2.0.1",
   "shortDescription": "Prysm ETH2.0 Beacon chain (Mainnet)",
   "description": "ETH2 Mainnet beacon chain",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 services:
   prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:
-    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.34'
+    image: 'prysm-beacon-chain-mainnet.avado.dnp.dappnode.eth:0.0.35'
     build:
       context: ./build
       args:
-        VERSION: v2.0.0
+        VERSION: v2.0.1
     volumes:
       - 'data:/data'
     ports:

--- a/releases.json
+++ b/releases.json
@@ -509,5 +509,12 @@
     "uploadedTo": {
       "http://80.208.229.228:5001": "Mon, 04 Oct 2021 19:41:00 GMT"
     }
+  },
+  "0.0.35": {
+    "hash": "/ipfs/QmPkGWkyf3fEaJbx8uRwp4WuwjPQ68FqXxU6RCQFmgpdiQ",
+    "type": "manifest",
+    "uploadedTo": {
+      "http://80.208.229.228:5001": "Thu, 07 Oct 2021 07:07:31 GMT"
+    }
   }
 }


### PR DESCRIPTION
https://github.com/prysmaticlabs/prysm/releases/tag/v2.0.1

Manifest hash: /ipfs/QmPkGWkyf3fEaJbx8uRwp4WuwjPQ68FqXxU6RCQFmgpdiQ