### PR TITLE
Autorestart for all non-0 exitcodes

### DIFF
--- a/build/supervisord.conf
+++ b/build/supervisord.conf
@@ -16,7 +16,7 @@ serverurl=unix:///dev/shm/supervisor.sock
 port = localhost:5555
 
 [program:prysmbeaconchain]
-command=/bin/sh -c "/opt/prysm/startPrysmBeaconchain.sh /data/settings.json"
+command=/opt/prysm/startPrysmBeaconchain.sh /data/settings.json
 autostart=true
 startsecs=10
 stdout_logfile=/dev/stdout
@@ -25,6 +25,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 killasgroup=true
 stopasgroup=true
+exitcodes=0
 
 [program:nginx]
 command=nginx -c /etc/nginx/nginx.conf -g "daemon off;"


### PR DESCRIPTION
Make sure Prysm restarts when it crashes:

See in log from user
```
+0x715 2022-09-01 10:44:18,045 INFO exited: prysmbeaconchain (exit status 2; expected) [172.33.1.20]
```

http://supervisord.org/configuration.html:
`In Supervisor versions prior to 4.0, the default was 0..2. In Supervisor 4.0, the default was changed to 0.`

