### PR TITLE
fix(ci): update every version-bearing file in the upstream-bump workflow

### DIFF
--- a/.github/scripts/update_upstream.py
+++ b/.github/scripts/update_upstream.py
@@ -96,10 +96,26 @@ def main():
     # Get the repository root directory
     repo_root = Path(__file__).parent.parent.parent
     
-    # File paths - mainnet only
-    dappnode_package_path = repo_root / "dappnode_package.json"
-    docker_compose_path = repo_root / "build" / "docker-compose.yml"
-    
+    # File paths - mainnet only. Every file that carries the package version or
+    # the upstream version must move together:
+    #   - dappnode_package.json          the published manifest (canonical: current versions are read from it)
+    #   - docker-compose.yml             what the release action publishes; the build arg here is what
+    #                                    actually gets built, so skipping it ships a different client
+    #                                    than the manifest advertises
+    #   - build/docker-compose.yml       the build source
+    #   - *-mainnet.*                    templates that setNetwork.sh hard-links over the live files,
+    #                                    silently reverting the package if they lag behind
+    dappnode_package_paths = [
+        repo_root / "dappnode_package.json",
+        repo_root / "dappnode_package-mainnet.json",
+    ]
+    docker_compose_paths = [
+        repo_root / "docker-compose.yml",
+        repo_root / "build" / "docker-compose.yml",
+        repo_root / "build" / "docker-compose-mainnet.yml",
+    ]
+    canonical_package_path = dappnode_package_paths[0]
+
     print("Checking for Prysm updates...")
     
     # Get latest Prysm release
@@ -107,7 +123,7 @@ def main():
     print(f"Latest Prysm version: {latest_prysm_version}")
     
     # Read current upstream version
-    with open(dappnode_package_path, 'r') as f:
+    with open(canonical_package_path, 'r') as f:
         current_data = json.load(f)
     
     current_upstream = current_data.get('upstream', '')
@@ -136,12 +152,21 @@ def main():
     print(f"New package version: {new_package_version}")
     
     # Update files
-    print("Updating dappnode_package.json...")
-    update_dappnode_package(dappnode_package_path, new_package_version, latest_prysm_version)
-    
-    print("Updating build/docker-compose.yml...")
-    update_docker_compose(docker_compose_path, new_package_version, latest_prysm_version)
-    
+    missing = [p for p in dappnode_package_paths + docker_compose_paths if not p.exists()]
+    if missing:
+        print("Error: expected version-bearing files are missing:", file=sys.stderr)
+        for p in missing:
+            print(f"  {p.relative_to(repo_root)}", file=sys.stderr)
+        sys.exit(1)
+
+    for path in dappnode_package_paths:
+        print(f"Updating {path.relative_to(repo_root)}...")
+        update_dappnode_package(path, new_package_version, latest_prysm_version)
+
+    for path in docker_compose_paths:
+        print(f"Updating {path.relative_to(repo_root)}...")
+        update_docker_compose(path, new_package_version, latest_prysm_version)
+
     print("Update complete!")
     
     # Set GitHub Actions output

--- a/.github/workflows/update_upstream.yml
+++ b/.github/workflows/update_upstream.yml
@@ -43,10 +43,14 @@ jobs:
             This PR updates the Prysm upstream version from **${{ env.old_version }}** to **${{ env.new_version }}** for mainnet only.
             
             ### Changes:
-            - Updated `upstream` in `dappnode_package-mainnet.json` to `${{ env.new_version }}`
-            - Incremented `version` in `dappnode_package-mainnet.json` to `${{ env.package_version }}`
-            - Updated `image` tag in `build/docker-compose-mainnet.yml` to `${{ env.package_version }}`
-            - Updated `PRYSM_VERSION` build argument in `build/docker-compose-mainnet.yml` to `${{ env.new_version }}`
+            `upstream` -> `${{ env.new_version }}` and `version` -> `${{ env.package_version }}` in:
+            - `dappnode_package.json`
+            - `dappnode_package-mainnet.json`
+
+            `image` tag -> `${{ env.package_version }}` and `PRYSM_VERSION` -> `${{ env.new_version }}` in:
+            - `docker-compose.yml` (published by the release action - the build arg here is what actually gets built)
+            - `build/docker-compose.yml`
+            - `build/docker-compose-mainnet.yml` (template `setNetwork.sh` hard-links over the live file)
             
             ### Release Notes:
             See [OffchainLabs/prysm releases](https://github.com/OffchainLabs/prysm/releases/tag/${{ env.new_version }})


### PR DESCRIPTION
The update script wrote `dappnode_package.json` and `build/docker-compose.yml`, but left the repo-root `docker-compose.yml` alone. That root file is what the release action publishes, and **its build arg is what actually gets built** — so once the release action materialises it (it starts life as a symlink), it freezes at whatever upstream version was pinned at that moment while the manifest keeps advancing.

This is not hypothetical: the Nimbus package has been publishing Nimbus v26.2.0 under a v26.7.0 manifest for months for exactly this reason. This repo is one release away from the same drift.

The `*-mainnet.*` templates were skipped for the same reason. `setNetwork.sh` hard-links those over the live files, so a stale template silently reverts the package.

### Changes
- All five version-bearing files now move together: `dappnode_package.json`, `dappnode_package-mainnet.json`, `docker-compose.yml`, `build/docker-compose.yml`, `build/docker-compose-mainnet.yml`
- Script fails loudly if any expected file is missing, instead of silently updating a subset
- PR body now lists what it actually touches — it previously named `-mainnet` files the script never wrote

### Verification
Ran the script against a scratch copy with the version rewound to v7.1.0 and confirmed all five files land on the same values:

```
Updating dappnode_package.json...
Updating dappnode_package-mainnet.json...
Updating docker-compose.yml...
Updating build/docker-compose.yml...
Updating build/docker-compose-mainnet.yml...
```

Nethermind and dappnode-geth already did this correctly and need no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHvb13D4DKoAvKs1vuRq3